### PR TITLE
fix: comment update 시 createdAt null 오류 수정

### DIFF
--- a/src/main/java/api/store/diglog/controller/CommentController.java
+++ b/src/main/java/api/store/diglog/controller/CommentController.java
@@ -34,7 +34,7 @@ public class CommentController {
         return ResponseEntity.ok().body(comments);
     }
 
-    @PatchMapping()
+    @PatchMapping
     public ResponseEntity<Void> update(@RequestBody CommentUpdateRequest commentUpdateRequest) {
         commentService.update(commentUpdateRequest);
 

--- a/src/main/java/api/store/diglog/model/dto/comment/CommentListRequest.java
+++ b/src/main/java/api/store/diglog/model/dto/comment/CommentListRequest.java
@@ -11,5 +11,4 @@ public class CommentListRequest {
     private UUID parentCommentId;
     private int page;
     private int size;
-
 }

--- a/src/main/java/api/store/diglog/model/entity/Comment.java
+++ b/src/main/java/api/store/diglog/model/entity/Comment.java
@@ -47,7 +47,7 @@ public class Comment {
     private LocalDateTime updatedAt;
 
     @Builder
-    public Comment(UUID id, Post post, Member member, String content, boolean isDeleted, Comment parentComment, Member taggedMember) {
+    public Comment(UUID id, Post post, Member member, String content, boolean isDeleted, Comment parentComment, Member taggedMember, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.post = post;
         this.member = member;
@@ -55,5 +55,7 @@ public class Comment {
         this.isDeleted = isDeleted;
         this.parentComment = parentComment;
         this.taggedMember = taggedMember;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
     }
 }

--- a/src/main/java/api/store/diglog/service/CommentService.java
+++ b/src/main/java/api/store/diglog/service/CommentService.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import static api.store.diglog.common.exception.ErrorCode.*;
@@ -108,6 +109,7 @@ public class CommentService {
                 .parentComment(comment.getParentComment())
                 .member(member)
                 .isDeleted(comment.isDeleted())
+                .createdAt(comment.getCreatedAt())
                 .build();
         commentRepository.save(updateComment);
     }


### PR DESCRIPTION
## 📝 요약(Summary)

- 댓글 update 시 createdAt 이 null이 되는 오류 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어 (선택)

- 지금 방법은 id가 같은 새로운 Entity를 Builder 패턴으로 새로 생성해서 save 하지만, content와 taggedUsername을 변경하는 메서드를 Entity에 넣는 것을 고려해봐도 좋을 것 같습니다.

## 📸스크린샷 (선택)
