### PR TITLE
feat: 게시글 조회 시 폴더 정보 추가

### DIFF
--- a/src/main/java/api/store/diglog/model/dto/folder/FolderPostResponse.java
+++ b/src/main/java/api/store/diglog/model/dto/folder/FolderPostResponse.java
@@ -1,0 +1,15 @@
+package api.store.diglog.model.dto.folder;
+
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class FolderPostResponse {
+
+    private UUID id;
+    private String title;
+}

--- a/src/main/java/api/store/diglog/model/dto/post/PostListMemberRequest.java
+++ b/src/main/java/api/store/diglog/model/dto/post/PostListMemberRequest.java
@@ -2,6 +2,7 @@ package api.store.diglog.model.dto.post;
 
 import lombok.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -12,7 +13,7 @@ import java.util.UUID;
 public class PostListMemberRequest {
 
     private String username;
-    private UUID folderId;
+    private List<UUID> folderIds;
     private int page;
     private int size;
 }

--- a/src/main/java/api/store/diglog/model/dto/post/PostResponse.java
+++ b/src/main/java/api/store/diglog/model/dto/post/PostResponse.java
@@ -1,5 +1,6 @@
 package api.store.diglog.model.dto.post;
 
+import api.store.diglog.model.dto.folder.FolderPostResponse;
 import api.store.diglog.model.dto.tag.TagResponse;
 import api.store.diglog.model.entity.Post;
 import lombok.*;
@@ -18,6 +19,7 @@ public class PostResponse {
     private String title;
     private String content;
     private String username;
+    private FolderPostResponse folder;
     private List<TagResponse> tags;
     private LocalDateTime createdAt;
 
@@ -30,5 +32,12 @@ public class PostResponse {
                 .map(TagResponse::new)
                 .toList();
         this.createdAt = post.getCreatedAt();
+
+        if (post.getFolder() != null) {
+            this.folder = FolderPostResponse.builder()
+                    .id(post.getFolder().getId())
+                    .title(post.getFolder().getTitle())
+                    .build();
+        }
     }
 }

--- a/src/main/java/api/store/diglog/repository/FolderRepository.java
+++ b/src/main/java/api/store/diglog/repository/FolderRepository.java
@@ -1,5 +1,6 @@
 package api.store.diglog.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -10,4 +11,6 @@ import api.store.diglog.model.entity.Folder;
 public interface FolderRepository extends JpaRepository<Folder, UUID> {
 
     Optional<Folder> findByIdAndMemberId(UUID id, UUID memberId);
+
+    List<Folder> findAllByIdIn(List<UUID> folderIds);
 }

--- a/src/main/java/api/store/diglog/repository/PostRepository.java
+++ b/src/main/java/api/store/diglog/repository/PostRepository.java
@@ -27,6 +27,8 @@ public interface PostRepository extends JpaRepository<Post, UUID> {
 
     Page<Post> findAllByMemberIdAndIsDeletedFalse(UUID memberId, Pageable pageable);
 
+    Page<Post> findAllByMemberIdAndFolderIdInAndIsDeletedFalse(UUID memberId, List<UUID> folderIds, Pageable pageable);
+
     List<Post> findAllByIdInAndMemberId(List<UUID> ids, UUID memberId);
 
     @Modifying

--- a/src/main/java/api/store/diglog/service/FolderService.java
+++ b/src/main/java/api/store/diglog/service/FolderService.java
@@ -156,4 +156,8 @@ public class FolderService {
         return folderRepository.findByIdAndMemberId(folderId, memberId)
                 .orElseThrow(() -> new CustomException(FOLDER_OWNER_MISMATCH));
     }
+
+	public List<Folder> getFoldersByIdList(List<UUID> folderIds) {
+		return folderRepository.findAllByIdIn(folderIds);
+	}
 }

--- a/src/main/java/api/store/diglog/service/PostService.java
+++ b/src/main/java/api/store/diglog/service/PostService.java
@@ -162,7 +162,15 @@ public class PostService {
                 Sort.by("createdAt", "id").descending());
         Member member = memberService.findActiveMemberByUsername(postListMemberRequest.getUsername());
 
-        return postRepository.findAllByMemberIdAndIsDeletedFalse(member.getId(), pageable)
+        if (postListMemberRequest.getFolderIds().isEmpty()) {
+            return postRepository.findAllByMemberIdAndIsDeletedFalse(member.getId(), pageable)
+                    .map(PostResponse::new);
+        }
+
+        List<UUID> folderIds = folderService.getFoldersByIdList(postListMemberRequest.getFolderIds())
+                .stream().map(Folder::getId)
+                .toList();
+        return postRepository.findAllByMemberIdAndFolderIdInAndIsDeletedFalse(member.getId(), folderIds, pageable)
                 .map(PostResponse::new);
     }
 


### PR DESCRIPTION

## 📝 요약(Summary)

- 게시글 조회 정보에 폴더 id, title이 포함되도록 수정
- 멤버의 게시글 조회 기능을 다수의 폴더id를 담을 수 있도록 수정
  - 상위, 하위 폴더의 id List를 프론트에서 보내는 방식

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어 (선택)

## 📸스크린샷 (선택)
