### PR TITLE
Feature/folder

### DIFF
--- a/src/main/java/api/store/diglog/common/config/SecurityConfig.java
+++ b/src/main/java/api/store/diglog/common/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
         String[] memberApi = {"/api/member/login", "/api/member/logout", "/api/member/refresh", "/api/member/profile/*", "/api/member/profile/search/*", "/api/verify/**"};
         String[] postGetApi = {"/api/post", "/api/post/*", "/api/post/search"};
         String[] commentGetApi = {"/api/comment"};
+        String[] folderGetApi = {"/api/folders/**"};
 
         http
                 .authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
@@ -49,6 +50,7 @@ public class SecurityConfig {
                         .requestMatchers(memberApi).permitAll()
                         .requestMatchers(HttpMethod.GET, postGetApi).permitAll()
                         .requestMatchers(HttpMethod.GET, commentGetApi).permitAll()
+                        .requestMatchers(HttpMethod.GET, folderGetApi).permitAll()
                         .anyRequest().authenticated())
 
                 .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/api/store/diglog/controller/FolderController.java
+++ b/src/main/java/api/store/diglog/controller/FolderController.java
@@ -3,6 +3,8 @@ package api.store.diglog.controller;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +22,13 @@ import lombok.RequiredArgsConstructor;
 public class FolderController {
 
 	private final FolderService folderService;
+
+	@GetMapping("/{username}")
+	public ResponseEntity<List<FolderResponse>> getFoldersBy(@PathVariable("username") String username) {
+
+		List<FolderResponse> folderResponses = folderService.getFolders(username);
+		return ResponseEntity.ok().body(folderResponses);
+	}
 
 	@PutMapping
 	public ResponseEntity<List<FolderResponse>> createAndUpdate(

--- a/src/main/java/api/store/diglog/controller/FolderController.java
+++ b/src/main/java/api/store/diglog/controller/FolderController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import api.store.diglog.model.dto.folder.FolderCreateRequest;
+import api.store.diglog.model.dto.folder.FolderPostCountResponse;
 import api.store.diglog.model.dto.folder.FolderResponse;
 import api.store.diglog.service.FolderService;
 import jakarta.validation.Valid;
@@ -24,10 +25,11 @@ public class FolderController {
 	private final FolderService folderService;
 
 	@GetMapping("/{username}")
-	public ResponseEntity<List<FolderResponse>> getFoldersBy(@PathVariable("username") String username) {
+	public ResponseEntity<List<FolderPostCountResponse>> getFoldersWithPostCountBy(
+		@PathVariable("username") String username) {
 
-		List<FolderResponse> folderResponses = folderService.getFolders(username);
-		return ResponseEntity.ok().body(folderResponses);
+		List<FolderPostCountResponse> folderPostCountResponses = folderService.getFoldersWithPostCount(username);
+		return ResponseEntity.ok().body(folderPostCountResponses);
 	}
 
 	@PutMapping

--- a/src/main/java/api/store/diglog/model/dto/folder/FolderPostCountResponse.java
+++ b/src/main/java/api/store/diglog/model/dto/folder/FolderPostCountResponse.java
@@ -3,9 +3,11 @@ package api.store.diglog.model.dto.folder;
 import java.util.UUID;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @AllArgsConstructor
+@Builder
 @Getter
 public class FolderPostCountResponse {
 

--- a/src/main/java/api/store/diglog/model/dto/folder/FolderPostCountResponse.java
+++ b/src/main/java/api/store/diglog/model/dto/folder/FolderPostCountResponse.java
@@ -1,0 +1,19 @@
+package api.store.diglog.model.dto.folder;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class FolderPostCountResponse {
+
+	private UUID folderId;
+	private String title;
+	private int depth;
+	private int orderIndex;
+	private UUID parentFolderId;
+	private long postCount;
+
+}

--- a/src/main/java/api/store/diglog/model/entity/Folder.java
+++ b/src/main/java/api/store/diglog/model/entity/Folder.java
@@ -2,6 +2,7 @@ package api.store.diglog.model.entity;
 
 import static api.store.diglog.common.exception.ErrorCode.*;
 
+import java.util.Objects;
 import java.util.UUID;
 
 import api.store.diglog.common.exception.CustomException;
@@ -21,12 +22,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-//@Table(
-//	name = "folder",
-//	uniqueConstraints = {
-//		@UniqueConstraint(columnNames = {"member_id", "parent_id", "title"})
-//	}
-//)
+@Table(
+	name = "folder",
+	uniqueConstraints = {
+		@UniqueConstraint(columnNames = {"member_id", "parent_id", "title"})
+	}
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Folder {
@@ -103,4 +104,18 @@ public class Folder {
 		}
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		Folder folder = (Folder)o;
+		return Objects.equals(id, folder.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id);
+	}
 }

--- a/src/main/java/api/store/diglog/repository/FolderRepository.java
+++ b/src/main/java/api/store/diglog/repository/FolderRepository.java
@@ -7,11 +7,27 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import api.store.diglog.model.dto.folder.FolderPostCountResponse;
 import api.store.diglog.model.entity.Folder;
 import api.store.diglog.model.entity.Member;
 
 public interface FolderRepository extends JpaRepository<Folder, UUID> {
 
-	@Query("SELECT f FROM Folder f LEFT JOIN FETCH f.parentFolder WHERE f.member = :member")
-	List<Folder> findAllByMemberWithParent(@Param("member") Member member);
+	@Query("""
+		    SELECT new api.store.diglog.model.dto.folder.FolderPostCountResponse(
+		        f.id,
+		        f.title,
+		        f.depth,
+		        f.orderIndex,
+		        parent.id,
+		        COUNT(p.id)
+		    )
+		    FROM Folder f
+		    LEFT JOIN f.parentFolder parent
+		    LEFT JOIN Post p ON f.id = p.folder.id
+		    WHERE f.member = :member
+		    GROUP BY f.id
+		    ORDER BY f.orderIndex
+		""")
+	List<FolderPostCountResponse> findAllWithPostCountByMember(@Param("member") Member member);
 }

--- a/src/main/java/api/store/diglog/repository/FolderRepository.java
+++ b/src/main/java/api/store/diglog/repository/FolderRepository.java
@@ -1,11 +1,14 @@
 package api.store.diglog.repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import api.store.diglog.model.entity.Folder;
+import api.store.diglog.model.entity.Member;
 
 public interface FolderRepository extends JpaRepository<Folder, UUID> {
 
+	List<Folder> findAllByMember(Member member);
 }

--- a/src/main/java/api/store/diglog/repository/FolderRepository.java
+++ b/src/main/java/api/store/diglog/repository/FolderRepository.java
@@ -4,11 +4,14 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import api.store.diglog.model.entity.Folder;
 import api.store.diglog.model.entity.Member;
 
 public interface FolderRepository extends JpaRepository<Folder, UUID> {
 
-	List<Folder> findAllByMember(Member member);
+	@Query("SELECT f FROM Folder f LEFT JOIN FETCH f.parentFolder WHERE f.member = :member")
+	List<Folder> findAllByMemberWithParent(@Param("member") Member member);
 }

--- a/src/main/java/api/store/diglog/service/FolderService.java
+++ b/src/main/java/api/store/diglog/service/FolderService.java
@@ -2,7 +2,6 @@ package api.store.diglog.service;
 
 import static api.store.diglog.common.exception.ErrorCode.*;
 
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import api.store.diglog.common.exception.CustomException;
 import api.store.diglog.model.dto.folder.FolderCreateRequest;
+import api.store.diglog.model.dto.folder.FolderPostCountResponse;
 import api.store.diglog.model.dto.folder.FolderResponse;
 import api.store.diglog.model.entity.Folder;
 import api.store.diglog.model.entity.Member;
@@ -27,25 +27,17 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class FolderService {
-
 	private static final int MAX_FOLDER_SIZE = 100;
+
 	private static final String UNDER_BAR_SIGN = "_";
 
 	private final FolderRepository folderRepository;
 	private final MemberService memberService;
 
-	public List<FolderResponse> getFolders(String username) {
+	public List<FolderPostCountResponse> getFoldersWithPostCount(String username) {
 
 		Member member = memberService.findActiveMemberByUsername(username);
-
-		List<Folder> folders = folderRepository.findAllByMemberWithParent(member);
-		return folders.stream()
-			.map(folder -> FolderResponse.builder()
-				.folder(folder)
-				.build())
-			.sorted(Comparator.comparing(FolderResponse::getOrderIndex))
-			.toList();
-
+		return folderRepository.findAllWithPostCountByMember(member);
 	}
 
 	@Transactional

--- a/src/main/java/api/store/diglog/service/FolderService.java
+++ b/src/main/java/api/store/diglog/service/FolderService.java
@@ -2,6 +2,7 @@ package api.store.diglog.service;
 
 import static api.store.diglog.common.exception.ErrorCode.*;
 
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,20 @@ public class FolderService {
 
 	private final FolderRepository folderRepository;
 	private final MemberService memberService;
+
+	public List<FolderResponse> getFolders(String username) {
+
+		Member member = memberService.findActiveMemberByUsername(username);
+
+		List<Folder> folders = folderRepository.findAllByMember(member);
+		return folders.stream()
+			.map(folder -> FolderResponse.builder()
+				.folder(folder)
+				.build())
+			.sorted(Comparator.comparing(FolderResponse::getOrderIndex))
+			.toList();
+
+	}
 
 	@Transactional
 	public List<FolderResponse> createAndUpdateFolders(List<FolderCreateRequest> folderCreateRequests) {

--- a/src/main/java/api/store/diglog/service/FolderService.java
+++ b/src/main/java/api/store/diglog/service/FolderService.java
@@ -38,7 +38,7 @@ public class FolderService {
 
 		Member member = memberService.findActiveMemberByUsername(username);
 
-		List<Folder> folders = folderRepository.findAllByMember(member);
+		List<Folder> folders = folderRepository.findAllByMemberWithParent(member);
 		return folders.stream()
 			.map(folder -> FolderResponse.builder()
 				.folder(folder)

--- a/src/test/java/api/store/diglog/controller/FolderControllerTest.java
+++ b/src/test/java/api/store/diglog/controller/FolderControllerTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import api.store.diglog.model.constant.Platform;
 import api.store.diglog.model.constant.Role;
 import api.store.diglog.model.dto.folder.FolderCreateRequest;
+import api.store.diglog.model.dto.folder.FolderPostCountResponse;
 import api.store.diglog.model.dto.folder.FolderResponse;
 import api.store.diglog.model.entity.Folder;
 import api.store.diglog.model.entity.Member;
@@ -137,5 +138,69 @@ class FolderControllerTest {
 			.andExpect(jsonPath("$[2].depth").value(0))
 			.andExpect(jsonPath("$[2].orderIndex").value(2))
 			.andExpect(jsonPath("$[2].parentFolderId").value("none"));
+	}
+
+	@DisplayName("회원 이름을 통해 게시글 개수가 포함된 폴더 목록을 조회할 수 있다.")
+	@Test
+	@WithMockUser(username = EMAIL, password = PASSWORD)
+	void getFoldersWithPostCount() throws Exception {
+
+		List<FolderPostCountResponse> folderPostCountResponses = List.of(
+			FolderPostCountResponse.builder()
+				.folderId(UUID.randomUUID())
+				.title("test01")
+				.depth(0)
+				.orderIndex(0)
+				.parentFolderId(null)
+				.postCount(1L)
+				.build(),
+			FolderPostCountResponse.builder()
+				.folderId(UUID.randomUUID())
+				.title("test02")
+				.depth(0)
+				.orderIndex(1)
+				.parentFolderId(null)
+				.postCount(2L)
+				.build(),
+			FolderPostCountResponse.builder()
+				.folderId(UUID.randomUUID())
+				.title("test03")
+				.depth(0)
+				.orderIndex(2)
+				.parentFolderId(null)
+				.postCount(3L)
+				.build()
+		);
+
+		BDDMockito.given(folderService.getFoldersWithPostCount(any()))
+			.willReturn(folderPostCountResponses);
+
+		mockMvc.perform(
+				get("/api/folders/testUser")
+					.with(csrf())
+					.contentType(MediaType.APPLICATION_JSON)
+					.accept(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.length()").value(3))
+			.andExpect(jsonPath("$[0].folderId").value(folderPostCountResponses.get(0).getFolderId().toString()))
+			.andExpect(jsonPath("$[0].title").value("test01"))
+			.andExpect(jsonPath("$[0].depth").value(0))
+			.andExpect(jsonPath("$[0].orderIndex").value(0))
+			.andExpect(jsonPath("$[0].parentFolderId").doesNotExist())
+			.andExpect(jsonPath("$[0].postCount").value(1L))
+			.andExpect(jsonPath("$[1].folderId").value(folderPostCountResponses.get(1).getFolderId().toString()))
+			.andExpect(jsonPath("$[1].title").value("test02"))
+			.andExpect(jsonPath("$[1].depth").value(0))
+			.andExpect(jsonPath("$[1].orderIndex").value(1))
+			.andExpect(jsonPath("$[1].parentFolderId").doesNotExist())
+			.andExpect(jsonPath("$[1].postCount").value(2L))
+			.andExpect(jsonPath("$[2].folderId").value(folderPostCountResponses.get(2).getFolderId().toString()))
+			.andExpect(jsonPath("$[2].title").value("test03"))
+			.andExpect(jsonPath("$[2].depth").value(0))
+			.andExpect(jsonPath("$[2].orderIndex").value(2))
+			.andExpect(jsonPath("$[2].parentFolderId").doesNotExist())
+			.andExpect(jsonPath("$[2].postCount").value(3L));
 	}
 }

--- a/src/test/java/api/store/diglog/repository/FolderRepositoryTest.java
+++ b/src/test/java/api/store/diglog/repository/FolderRepositoryTest.java
@@ -1,0 +1,86 @@
+package api.store.diglog.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import api.store.diglog.model.constant.Platform;
+import api.store.diglog.model.constant.Role;
+import api.store.diglog.model.entity.Folder;
+import api.store.diglog.model.entity.Member;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class FolderRepositoryTest {
+
+	@Autowired
+	MemberRepository memberRepository;
+
+	@Autowired
+	FolderRepository folderRepository;
+
+	@DisplayName("회원 이름으로 폴더를 조회할 수 있다")
+	@Test
+	void findAllByMember() {
+
+		// given
+		Member member = Member.builder()
+			.email("testEmail@gmail.com")
+			.username("testUser")
+			.password("testPassword")
+			.roles(Set.of(Role.ROLE_USER, Role.ROLE_ADMIN))
+			.platform(Platform.SERVER)
+			.createdAt(LocalDateTime.of(2022, 2, 22, 12, 0))
+			.updatedAt(LocalDateTime.of(2022, 3, 22, 12, 0))
+			.build();
+
+		memberRepository.save(member);
+
+		Folder test01 = Folder.builder()
+			.id(UUID.randomUUID())
+			.member(member)
+			.title("test01")
+			.depth(0)
+			.orderIndex(0)
+			.parentFolder(null)
+			.build();
+		Folder test02 = Folder.builder()
+			.id(UUID.randomUUID())
+			.member(member)
+			.title("test02")
+			.depth(1)
+			.orderIndex(1)
+			.parentFolder(test01)
+			.build();
+		Folder test03 = Folder.builder()
+			.id(UUID.randomUUID())
+			.member(member)
+			.title("test03")
+			.depth(2)
+			.orderIndex(2)
+			.parentFolder(test02)
+			.build();
+
+		folderRepository.saveAll(List.of(test01, test02, test03));
+
+		// when
+		List<Folder> folders = folderRepository.findAllByMemberWithParent(member);
+
+		// then
+		assertThat(folders).hasSize(3)
+			.contains(test01, test02, test03);
+
+	}
+}


### PR DESCRIPTION
## 📝 요약(Summary)

- 폴더 조회 기능 구현
   -  사용자 이름을 통한 폴더 조회 기능 구현
   - 각 폴더의 게시글 개수는 쿼리의 집계 함수를 이용해 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어 (선택)

말씀해주신 각 폴더에 속한 게시글의 개수 필드를 추가했습니다. 쿼리의 left join과  집계 함수를 이용해 최대한 적은 쿼리로 조회 기능을 구현했습니다.


## 📸스크린샷 (선택)
