### PR TITLE
fix: JPA Timezone이 서버 Timezone과 관계없이 Asia/Seoul이 되도록 수정

### DIFF
--- a/src/main/java/api/store/diglog/common/config/TimezoneConfig.java
+++ b/src/main/java/api/store/diglog/common/config/TimezoneConfig.java
@@ -1,0 +1,16 @@
+package api.store.diglog.common.config;
+
+import java.util.TimeZone;
+
+import org.springframework.context.annotation.Configuration;
+
+import jakarta.annotation.PostConstruct;
+
+@Configuration
+public class TimezoneConfig {
+
+	@PostConstruct
+	public void started() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
+}


### PR DESCRIPTION
## 📝 요약(Summary)

- JPA의 Timezone을 Default(운영체제 Timezone) 에서 Asia/Seoul 로 변경

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어 (선택)

- RDS의 Timezone을 변경과 관계없이 @CreatedDate로 LocalDateTime에 자동 설정되는 시간은 기본적으로 운영체제 Timezone을 따르는 것을 확인하였고, 배포 환경과 관계없이 한국 표준시를 사용하도록 Config를 추가하였습니다.

- 다른 해결방법으로는 타임존 관련 정보가 없는 LocalDateTime 대신 ZonedDateTime을 사용하여 일괄적으로 국제 표준시로 관리 후, 한국 표준시로 변환하는 것도 고려해볼 수 있을 것 같습니다.

## 📸스크린샷 (선택)
