### PR TITLE
feat: Redis 기반 조회수 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation "org.testcontainers:redis"
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.session:spring-session-data-redis'

--- a/build.gradle
+++ b/build.gradle
@@ -39,15 +39,21 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.h2database:h2'
+    testImplementation 'org.testcontainers:testcontainers'
+    testImplementation 'org.testcontainers:mysql'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation "org.testcontainers:redis"
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.redisson:redisson-spring-boot-starter:3.45.0'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,11 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.45.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/api/store/diglog/DiglogApplication.java
+++ b/src/main/java/api/store/diglog/DiglogApplication.java
@@ -2,12 +2,8 @@ package api.store.diglog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableAsync
-@EnableScheduling
 public class DiglogApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/api/store/diglog/DiglogApplication.java
+++ b/src/main/java/api/store/diglog/DiglogApplication.java
@@ -2,9 +2,11 @@ package api.store.diglog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableAsync
 @EnableScheduling
 public class DiglogApplication {
 

--- a/src/main/java/api/store/diglog/DiglogApplication.java
+++ b/src/main/java/api/store/diglog/DiglogApplication.java
@@ -2,8 +2,10 @@ package api.store.diglog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class DiglogApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/api/store/diglog/common/config/AsyncConfig.java
+++ b/src/main/java/api/store/diglog/common/config/AsyncConfig.java
@@ -1,0 +1,29 @@
+package api.store.diglog.common.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+	private static final int CORE_POOL_SIZE = 4;
+	private static final int MAX_POOL_SIZE = 8;
+	private static final int QUEUE_CAPACITY = 500;
+	private static final String THREAD_NAME_PREFIX = "diglog-sync-";
+
+	@Bean(name = "syncExecutor")
+	public Executor syncExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(CORE_POOL_SIZE);
+		executor.setMaxPoolSize(MAX_POOL_SIZE);
+		executor.setQueueCapacity(QUEUE_CAPACITY);
+		executor.setThreadNamePrefix(THREAD_NAME_PREFIX);
+		executor.initialize();
+		return executor;
+	}
+}

--- a/src/main/java/api/store/diglog/common/config/RedisConfig.java
+++ b/src/main/java/api/store/diglog/common/config/RedisConfig.java
@@ -1,0 +1,44 @@
+package api.store.diglog.common.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	@Value("${spring.redis.host}")
+	private String host;
+
+	@Value("${spring.redis.port}")
+	private int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
+		redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+		return redisTemplate;
+	}
+
+	@Bean
+	public RedissonClient redissonClient() {
+		Config config = new Config();
+		config.useSingleServer()
+			.setAddress("redis://" + host + ":" + port);
+		return Redisson.create(config);
+	}
+
+}

--- a/src/main/java/api/store/diglog/common/config/RedisConfig.java
+++ b/src/main/java/api/store/diglog/common/config/RedisConfig.java
@@ -34,9 +34,15 @@ public class RedisConfig {
 	public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
 		RedisTemplate<String, String> template = new RedisTemplate<>();
 		template.setConnectionFactory(redisConnectionFactory);
-		template.setEnableTransactionSupport(true);
-		template.setDefaultSerializer(new StringRedisSerializer());
+
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new StringRedisSerializer());
+		template.setHashKeySerializer(new StringRedisSerializer());
+		template.setHashValueSerializer(new StringRedisSerializer());
+
+		template.setEnableTransactionSupport(false);
 		template.afterPropertiesSet();
+		
 		return template;
 	}
 

--- a/src/main/java/api/store/diglog/common/config/RedisConfig.java
+++ b/src/main/java/api/store/diglog/common/config/RedisConfig.java
@@ -6,7 +6,9 @@ import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -21,16 +23,21 @@ public class RedisConfig {
 	private int port;
 
 	@Bean
+	@Primary
 	public RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory(host, port);
+		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+		return new LettuceConnectionFactory(config);
 	}
 
 	@Bean
+	@Primary
 	public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
-		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
-		redisTemplate.setConnectionFactory(redisConnectionFactory);
-		redisTemplate.setDefaultSerializer(new StringRedisSerializer());
-		return redisTemplate;
+		RedisTemplate<String, String> template = new RedisTemplate<>();
+		template.setConnectionFactory(redisConnectionFactory);
+		template.setEnableTransactionSupport(true);
+		template.setDefaultSerializer(new StringRedisSerializer());
+		template.afterPropertiesSet();
+		return template;
 	}
 
 	@Bean

--- a/src/main/java/api/store/diglog/common/config/SchedulingConfig.java
+++ b/src/main/java/api/store/diglog/common/config/SchedulingConfig.java
@@ -1,9 +1,11 @@
 package api.store.diglog.common.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
 @EnableScheduling
+@Profile("!test")
 public class SchedulingConfig {
 }

--- a/src/main/java/api/store/diglog/common/config/SchedulingConfig.java
+++ b/src/main/java/api/store/diglog/common/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package api.store.diglog.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/api/store/diglog/common/config/SecurityConfig.java
+++ b/src/main/java/api/store/diglog/common/config/SecurityConfig.java
@@ -1,7 +1,5 @@
 package api.store.diglog.common.config;
 
-import api.store.diglog.common.auth.*;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -16,6 +14,13 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.filter.CorsFilter;
 
+import api.store.diglog.common.auth.CustomAccessDeniedHandler;
+import api.store.diglog.common.auth.CustomAuthenticationEntryPoint;
+import api.store.diglog.common.auth.CustomOAuth2FailureHandler;
+import api.store.diglog.common.auth.CustomOAuth2SuccessHandler;
+import api.store.diglog.common.auth.CustomOAuth2UserService;
+import api.store.diglog.common.auth.JWTFilter;
+import api.store.diglog.common.auth.JWTUtil;
 import lombok.RequiredArgsConstructor;
 
 @EnableWebSecurity
@@ -42,7 +47,7 @@ public class SecurityConfig {
 		String[] swaggerApi = {"/swagger-ui/**", "/bus/v3/api-docs/**", "/v3/api-docs/**"};
 		String[] memberApi = {"/api/member/login", "/api/member/logout", "/api/member/refresh", "/api/member/profile/*",
 			"/api/member/profile/search/*", "/api/verify/**"};
-		String[] postGetApi = {"/api/post", "/api/post/*", "/api/post/member/tag"};
+		String[] postGetApi = {"/api/post", "/api/post/*", "/api/post/member/tag", "/api/post/view/*"};
 		String[] commentGetApi = {"/api/comment"};
 		String[] folderGetApi = {"/api/folders/**"};
 		String[] tagGetApi = {"/api/tag/**"};

--- a/src/main/java/api/store/diglog/common/exception/ErrorCode.java
+++ b/src/main/java/api/store/diglog/common/exception/ErrorCode.java
@@ -56,8 +56,8 @@ public enum ErrorCode {
 	COMMENT_UPDATE_NO_AUTHORITY(BAD_REQUEST, "해당 댓글을 수정할 수 있는 권한이 없습니다."),
 
 	// Redis
-	REDIS_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "서버 상태가 불안정합니다. 잠시 후 다시 시도해주세요."),
-	INVALID_REDIS_VIEW_COUNT_VALUE(HttpStatus.INTERNAL_SERVER_ERROR, "조회수 정보가 잘못되었습니다."),
+	REDIS_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "서비스 연결에 실패했습니다. 잠시 후 다시 시도해주세요."),
+	INVALID_REDIS_VIEW_COUNT_VALUE(HttpStatus.INTERNAL_SERVER_ERROR, "조회수 처리에 실패했습니다. 잠시 후 다시 시도해주세요."),
 	REDIS_VIEW_COUNT_VALUE_MISSING(HttpStatus.INTERNAL_SERVER_ERROR, "조회수 정보를 불러올 수 없습니다. 잠시 후 다시 시도해주세요.");
 
 	private final HttpStatus status;

--- a/src/main/java/api/store/diglog/common/exception/ErrorCode.java
+++ b/src/main/java/api/store/diglog/common/exception/ErrorCode.java
@@ -54,7 +54,11 @@ public enum ErrorCode {
 	COMMENT_IS_DELETED_NO_CHANGE(BAD_REQUEST, "댓글 삭제 권한이 없거나, 삭제가 완료되지 않았습니다."),
 	COMMENT_NOT_FOUND(BAD_REQUEST, "해당 댓글을 찾을 수 없습니다."),
 	COMMENT_UPDATE_NO_AUTHORITY(BAD_REQUEST, "해당 댓글을 수정할 수 있는 권한이 없습니다."),
-	;
+
+	// Redis
+	REDIS_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "서버 상태가 불안정합니다. 잠시 후 다시 시도해주세요."),
+	INVALID_REDIS_VIEW_COUNT_VALUE(HttpStatus.INTERNAL_SERVER_ERROR, "조회수 정보가 잘못되었습니다."),
+	REDIS_VIEW_COUNT_VALUE_MISSING(HttpStatus.INTERNAL_SERVER_ERROR, "조회수 정보를 불러올 수 없습니다. 잠시 후 다시 시도해주세요.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/api/store/diglog/common/scheduler/SyncScheduler.java
+++ b/src/main/java/api/store/diglog/common/scheduler/SyncScheduler.java
@@ -12,7 +12,7 @@ public class SyncScheduler {
 
 	private final PostService postService;
 
-	@Scheduled(fixedDelay = 10_000)
+	@Scheduled(fixedDelay = 300_000)
 	public void syncPostViewCount() {
 		postService.syncPostViewCountToDb();
 	}

--- a/src/main/java/api/store/diglog/common/scheduler/SyncScheduler.java
+++ b/src/main/java/api/store/diglog/common/scheduler/SyncScheduler.java
@@ -3,7 +3,7 @@ package api.store.diglog.common.scheduler;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import api.store.diglog.service.PostService;
+import api.store.diglog.service.post.PostService;
 import lombok.RequiredArgsConstructor;
 
 @Component

--- a/src/main/java/api/store/diglog/common/scheduler/SyncScheduler.java
+++ b/src/main/java/api/store/diglog/common/scheduler/SyncScheduler.java
@@ -1,0 +1,19 @@
+package api.store.diglog.common.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import api.store.diglog.service.PostService;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SyncScheduler {
+
+	private final PostService postService;
+
+	@Scheduled(fixedDelay = 10_000)
+	public void syncPostViewCount() {
+		postService.syncPostViewCountToDb();
+	}
+}

--- a/src/main/java/api/store/diglog/common/util/BatchPartition.java
+++ b/src/main/java/api/store/diglog/common/util/BatchPartition.java
@@ -1,0 +1,34 @@
+package api.store.diglog.common.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import lombok.Getter;
+
+@Getter
+public class BatchPartition<T> {
+
+	private final List<List<T>> batches;
+
+	private BatchPartition(List<List<T>> source) {
+		this.batches = source;
+	}
+
+	public static <T> BatchPartition<T> of(List<T> source, int batchSize) {
+		if (source == null || source.isEmpty()) {
+			return new BatchPartition<>(List.of());
+		}
+
+		List<List<T>> batches = new ArrayList<>();
+		for (int i = 0; i < source.size(); i += batchSize) {
+			batches.add(source.subList(i, Math.min(i + batchSize, source.size())));
+		}
+
+		return new BatchPartition<>(batches);
+	}
+
+	public Stream<List<T>> stream() {
+		return batches.stream();
+	}
+}

--- a/src/main/java/api/store/diglog/controller/PostController.java
+++ b/src/main/java/api/store/diglog/controller/PostController.java
@@ -1,15 +1,30 @@
 package api.store.diglog.controller;
 
-import api.store.diglog.model.dto.post.*;
-import api.store.diglog.service.PostService;
-import lombok.RequiredArgsConstructor;
+import java.util.UUID;
 
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.UUID;
+import api.store.diglog.model.dto.post.PostFolderUpdateRequest;
+import api.store.diglog.model.dto.post.PostListMemberRequest;
+import api.store.diglog.model.dto.post.PostListMemberTagRequest;
+import api.store.diglog.model.dto.post.PostListSearchRequest;
+import api.store.diglog.model.dto.post.PostRequest;
+import api.store.diglog.model.dto.post.PostResponse;
+import api.store.diglog.model.dto.post.PostUpdateRequest;
+import api.store.diglog.model.dto.post.PostViewIncrementRequest;
+import api.store.diglog.service.PostService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/post")
@@ -83,5 +98,19 @@ public class PostController {
 		postService.delete(id);
 
 		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/view/increment")
+	public ResponseEntity<Void> increasePostView(
+		@RequestBody PostViewIncrementRequest postViewIncrementRequest,
+		HttpServletRequest httpServletRequest
+	) {
+		String clientIp = httpServletRequest.getHeader("X-Forwarded-For");
+		if (clientIp == null) {
+			clientIp = httpServletRequest.getRemoteAddr();
+		}
+
+		postService.increaseView(postViewIncrementRequest,clientIp);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/api/store/diglog/controller/PostController.java
+++ b/src/main/java/api/store/diglog/controller/PostController.java
@@ -23,7 +23,7 @@ import api.store.diglog.model.dto.post.PostResponse;
 import api.store.diglog.model.dto.post.PostUpdateRequest;
 import api.store.diglog.model.dto.post.PostViewIncrementRequest;
 import api.store.diglog.model.dto.post.PostViewResponse;
-import api.store.diglog.service.PostService;
+import api.store.diglog.service.post.PostService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/api/store/diglog/controller/PostController.java
+++ b/src/main/java/api/store/diglog/controller/PostController.java
@@ -22,6 +22,7 @@ import api.store.diglog.model.dto.post.PostRequest;
 import api.store.diglog.model.dto.post.PostResponse;
 import api.store.diglog.model.dto.post.PostUpdateRequest;
 import api.store.diglog.model.dto.post.PostViewIncrementRequest;
+import api.store.diglog.model.dto.post.PostViewResponse;
 import api.store.diglog.service.PostService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -110,7 +111,13 @@ public class PostController {
 			clientIp = httpServletRequest.getRemoteAddr();
 		}
 
-		postService.increaseView(postViewIncrementRequest,clientIp);
+		postService.increaseView(postViewIncrementRequest, clientIp);
 		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/view/{id}")
+	public ResponseEntity<PostViewResponse> getPostView(@PathVariable(value = "id") UUID id) {
+		PostViewResponse postViewResponse = postService.getViewCount(id);
+		return ResponseEntity.ok().body(postViewResponse);
 	}
 }

--- a/src/main/java/api/store/diglog/model/dto/post/PostViewIncrementRequest.java
+++ b/src/main/java/api/store/diglog/model/dto/post/PostViewIncrementRequest.java
@@ -1,0 +1,19 @@
+package api.store.diglog.model.dto.post;
+
+import java.util.UUID;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class PostViewIncrementRequest {
+
+	private UUID postId;
+
+}

--- a/src/main/java/api/store/diglog/model/dto/post/PostViewResponse.java
+++ b/src/main/java/api/store/diglog/model/dto/post/PostViewResponse.java
@@ -1,0 +1,20 @@
+package api.store.diglog.model.dto.post;
+
+import java.util.UUID;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostViewResponse {
+
+	private UUID postId;
+	private long viewCount;
+
+}

--- a/src/main/java/api/store/diglog/model/entity/Post.java
+++ b/src/main/java/api/store/diglog/model/entity/Post.java
@@ -1,15 +1,29 @@
 package api.store.diglog.model.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 
+import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
@@ -41,6 +55,10 @@ public class Post {
 	@Column(nullable = false, columnDefinition = "TEXT")
 	private String content;
 
+	@Column(nullable = false)
+	@ColumnDefault("1")
+	private long viewCount;
+
 	@Column(nullable = false, columnDefinition = "boolean default false")
 	private boolean isDeleted;
 
@@ -66,5 +84,14 @@ public class Post {
 
 	public void updateFolder(Folder folder) {
 		this.folder = folder;
+	}
+
+	public void updateViewCount(long viewCount) {
+
+		if (this.viewCount > viewCount) {
+			throw new IllegalArgumentException("조회수 에러");
+		}
+
+		this.viewCount = viewCount;
 	}
 }

--- a/src/main/java/api/store/diglog/model/entity/Post.java
+++ b/src/main/java/api/store/diglog/model/entity/Post.java
@@ -21,6 +21,7 @@ import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,6 +30,8 @@ import lombok.NoArgsConstructor;
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Post {
 
 	@Id
@@ -57,7 +60,8 @@ public class Post {
 
 	@Column(nullable = false)
 	@ColumnDefault("1")
-	private long viewCount;
+	@Builder.Default
+	private long viewCount = 1;
 
 	@Column(nullable = false, columnDefinition = "boolean default false")
 	private boolean isDeleted;
@@ -67,20 +71,6 @@ public class Post {
 
 	@LastModifiedDate
 	private LocalDateTime updatedAt;
-
-	@Builder
-	public Post(UUID id, Member member, Folder folder, List<Tag> tags, String title, String content, boolean isDeleted,
-		LocalDateTime createdAt, LocalDateTime updatedAt) {
-		this.id = id;
-		this.member = member;
-		this.folder = folder;
-		this.tags = tags;
-		this.title = title;
-		this.content = content;
-		this.isDeleted = isDeleted;
-		this.createdAt = createdAt;
-		this.updatedAt = updatedAt;
-	}
 
 	public void updateFolder(Folder folder) {
 		this.folder = folder;

--- a/src/main/java/api/store/diglog/model/entity/Post.java
+++ b/src/main/java/api/store/diglog/model/entity/Post.java
@@ -76,12 +76,4 @@ public class Post {
 		this.folder = folder;
 	}
 
-	public void updateViewCount(long viewCount) {
-
-		if (this.viewCount > viewCount) {
-			throw new IllegalArgumentException("조회수 에러");
-		}
-
-		this.viewCount = viewCount;
-	}
 }

--- a/src/main/java/api/store/diglog/repository/PostViewBatchRepository.java
+++ b/src/main/java/api/store/diglog/repository/PostViewBatchRepository.java
@@ -1,0 +1,10 @@
+package api.store.diglog.repository;
+
+import java.util.Map;
+import java.util.UUID;
+
+public interface PostViewBatchRepository {
+
+	void bulkUpdateViewCounts(Map<UUID, Long> viewCounts);
+
+}

--- a/src/main/java/api/store/diglog/repository/PostViewBatchRepositoryImpl.java
+++ b/src/main/java/api/store/diglog/repository/PostViewBatchRepositoryImpl.java
@@ -1,0 +1,47 @@
+package api.store.diglog.repository;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Repository
+public class PostViewBatchRepositoryImpl implements PostViewBatchRepository {
+
+	private static final String SQL_UPDATE_VIEW_COUNT_PREFIX = "UPDATE post SET view_count = CASE id ";
+	private static final String SQL_WHEN_CLAUSE_FORMAT = "WHEN '%s' THEN '%d' ";
+	private static final String SQL_UPDATE_VIEW_COUNT_SUFFIX = "END WHERE id IN (%s);";
+	private static final String SQL_STRING_WRAPPER = "'";
+	private static final String SQL_IN_CLAUSE_DELIMITER = ",";
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Override
+	@Transactional
+	public void bulkUpdateViewCounts(Map<UUID, Long> viewCounts) {
+		if (viewCounts.isEmpty()) {
+			return;
+		}
+
+		String sql = makeUpdateViewCountSql(viewCounts);
+		entityManager.createNativeQuery(sql).executeUpdate();
+	}
+
+	private String makeUpdateViewCountSql(Map<UUID, Long> viewCounts) {
+		StringBuilder sql = new StringBuilder(SQL_UPDATE_VIEW_COUNT_PREFIX);
+		for (Map.Entry<UUID, Long> entry : viewCounts.entrySet()) {
+			sql.append(String.format(SQL_WHEN_CLAUSE_FORMAT, entry.getKey(), entry.getValue()));
+		}
+		String idList = viewCounts.keySet().stream()
+			.map(uuid -> SQL_STRING_WRAPPER + uuid + SQL_STRING_WRAPPER)
+			.collect(Collectors.joining(SQL_IN_CLAUSE_DELIMITER));
+		sql.append(String.format(SQL_UPDATE_VIEW_COUNT_SUFFIX, idList));
+		return sql.toString();
+	}
+}

--- a/src/main/java/api/store/diglog/service/PostService.java
+++ b/src/main/java/api/store/diglog/service/PostService.java
@@ -29,6 +29,7 @@ import api.store.diglog.model.dto.post.PostRequest;
 import api.store.diglog.model.dto.post.PostResponse;
 import api.store.diglog.model.dto.post.PostUpdateRequest;
 import api.store.diglog.model.dto.post.PostViewIncrementRequest;
+import api.store.diglog.model.dto.post.PostViewResponse;
 import api.store.diglog.model.entity.Folder;
 import api.store.diglog.model.entity.Member;
 import api.store.diglog.model.entity.Post;
@@ -257,6 +258,18 @@ public class PostService {
 			redisTemplate.opsForSet().remove("post:view:dirtySet", postId)
 		);
 
+	}
+
+	public PostViewResponse getViewCount(UUID id) {
+
+		String countKey = "post:view:count:" + id;
+		loadPostViewIntoRedis(countKey, id);
+
+		String viewCount = redisTemplate.opsForValue().get(countKey);
+		return PostViewResponse.builder()
+			.postId(id)
+			.viewCount(Long.parseLong(viewCount))
+			.build();
 	}
 
 	private void loadPostViewIntoRedis(String countKey, UUID postId) {

--- a/src/main/java/api/store/diglog/service/post/PostAsyncWorker.java
+++ b/src/main/java/api/store/diglog/service/post/PostAsyncWorker.java
@@ -1,0 +1,51 @@
+package api.store.diglog.service.post;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import api.store.diglog.repository.PostViewBatchRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PostAsyncWorker {
+
+	private static final String REDIS_KEY_PREFIX_POST_VIEW = "post:view:";
+	private static final String REDIS_KEY_PREFIX_VIEW_COUNT = REDIS_KEY_PREFIX_POST_VIEW + "count:";
+	private static final String REDIS_KEY_VIEW_COUNT_DIRTY_SET = REDIS_KEY_PREFIX_POST_VIEW + "dirtySet";
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final PostViewBatchRepository postViewBatchRepository;
+
+	@Async("syncExecutor")
+	public void syncViewCountAllInBatch(List<UUID> postIds) {
+
+		Map<UUID, Long> viewCounts = postIds.stream()
+			.map(id -> {
+				String countKey = REDIS_KEY_PREFIX_VIEW_COUNT + id;
+				String value = redisTemplate.opsForValue().get(countKey);
+				try {
+					return Map.entry(id, Long.parseLong(value));
+				} catch (NumberFormatException e) {
+					return null;
+				}
+			})
+			.filter(Objects::nonNull)
+			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+		if (!viewCounts.isEmpty()) {
+			postViewBatchRepository.bulkUpdateViewCounts(viewCounts);
+			viewCounts.keySet().forEach(postId ->
+				redisTemplate.opsForSet().remove(REDIS_KEY_VIEW_COUNT_DIRTY_SET, postId.toString())
+			);
+		}
+	}
+
+}

--- a/src/main/java/api/store/diglog/service/post/PostAsyncWorker.java
+++ b/src/main/java/api/store/diglog/service/post/PostAsyncWorker.java
@@ -2,7 +2,7 @@ package api.store.diglog.service.post;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -10,42 +10,94 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+import api.store.diglog.model.entity.Post;
+import api.store.diglog.repository.PostRepository;
 import api.store.diglog.repository.PostViewBatchRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class PostAsyncWorker {
 
 	private static final String REDIS_KEY_PREFIX_POST_VIEW = "post:view:";
 	private static final String REDIS_KEY_PREFIX_VIEW_COUNT = REDIS_KEY_PREFIX_POST_VIEW + "count:";
 	private static final String REDIS_KEY_VIEW_COUNT_DIRTY_SET = REDIS_KEY_PREFIX_POST_VIEW + "dirtySet";
 
+	private static final String LOG_VIEW_COUNT_NULL = "[조회수 부재] postId={}";
+	private static final String LOG_VIEW_COUNT_PARSE_FAIL = "[조회수 파싱 실패] postId={}, RedisViewCountValue={}";
+	private static final String LOG_VIEW_COUNT_REVERSED = "[조회수 역전 감지] postId={}, Redis={}, DB={}";
+
 	private final RedisTemplate<String, String> redisTemplate;
 	private final PostViewBatchRepository postViewBatchRepository;
+	private final PostRepository postRepository;
 
 	@Async("syncExecutor")
 	public void syncViewCountAllInBatch(List<UUID> postIds) {
+		Map<UUID, Long> validViewCounts = extractValidRedisViewCounts(postIds);
+		Map<UUID, Long> consistentViewCounts = filterConsistentViewCounts(validViewCounts);
+		updateViewCountsAndCleanupDirtySet(consistentViewCounts);
+	}
 
-		Map<UUID, Long> viewCounts = postIds.stream()
+	private Map<UUID, Long> extractValidRedisViewCounts(List<UUID> postIds) {
+		return postIds.stream()
 			.map(id -> {
 				String countKey = REDIS_KEY_PREFIX_VIEW_COUNT + id;
-				String value = redisTemplate.opsForValue().get(countKey);
-				try {
-					return Map.entry(id, Long.parseLong(value));
-				} catch (NumberFormatException e) {
-					return null;
-				}
+				String redisViewCountValue = redisTemplate.opsForValue().get(countKey);
+				return Map.entry(id, redisViewCountValue);
 			})
-			.filter(Objects::nonNull)
-			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+			.filter(redisViewCount -> isValidRedisViewCount(redisViewCount.getKey(), redisViewCount.getValue()))
+			.collect(Collectors.toMap(
+				Map.Entry::getKey,
+				redisViewCount -> Long.parseLong(redisViewCount.getValue())
+			));
+	}
 
-		if (!viewCounts.isEmpty()) {
-			postViewBatchRepository.bulkUpdateViewCounts(viewCounts);
-			viewCounts.keySet().forEach(postId ->
-				redisTemplate.opsForSet().remove(REDIS_KEY_VIEW_COUNT_DIRTY_SET, postId.toString())
-			);
+	private boolean isValidRedisViewCount(UUID postId, String redisViewCountValue) {
+		if (redisViewCountValue == null) {
+			log.error(LOG_VIEW_COUNT_NULL, postId);
+			return false;
+		}
+
+		try {
+			Long.parseLong(redisViewCountValue);
+			return true;
+		} catch (NumberFormatException e) {
+			log.error(LOG_VIEW_COUNT_PARSE_FAIL, postId, redisViewCountValue);
+			return false;
 		}
 	}
 
+	private Map<UUID, Long> filterConsistentViewCounts(Map<UUID, Long> redisViewCounts) {
+		return postRepository.findAllById(redisViewCounts.keySet()).stream()
+			.filter(post -> isConsistentViewCount(post, redisViewCounts.get(post.getId())))
+			.collect(Collectors.toMap(
+				Post::getId,
+				post -> redisViewCounts.get(post.getId())
+			));
+	}
+
+	private boolean isConsistentViewCount(Post post, long redisViewCount) {
+		if (post.getViewCount() > redisViewCount) {
+			log.error(LOG_VIEW_COUNT_REVERSED, post.getId(), redisViewCount, post.getViewCount());
+			return false;
+		}
+		return true;
+	}
+
+	private void updateViewCountsAndCleanupDirtySet(Map<UUID, Long> viewCounts) {
+		if (viewCounts.isEmpty()) {
+			return;
+		}
+
+		postViewBatchRepository.bulkUpdateViewCounts(viewCounts);
+		cleanupDirtySet(viewCounts.keySet());
+	}
+
+	private void cleanupDirtySet(Set<UUID> processedPostIds) {
+		processedPostIds.forEach(postId ->
+			redisTemplate.opsForSet().remove(REDIS_KEY_VIEW_COUNT_DIRTY_SET, postId.toString())
+		);
+	}
 }

--- a/src/main/java/api/store/diglog/service/post/RedisPostViewLoader.java
+++ b/src/main/java/api/store/diglog/service/post/RedisPostViewLoader.java
@@ -1,0 +1,66 @@
+package api.store.diglog.service.post;
+
+import static api.store.diglog.common.exception.ErrorCode.*;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import api.store.diglog.common.exception.CustomException;
+import api.store.diglog.model.entity.Post;
+import api.store.diglog.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisPostViewLoader {
+
+	private static final int LOCK_WAIT_TIME = 3;
+	private static final int LOCK_LEASE_TIME = 1;
+	private static final String LOCK_KEY_SUFFIX = ":lock";
+	private static final int DAILY_TTL_HOURS = 24;
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final RedissonClient redissonClient;
+	private final PostRepository postRepository;
+
+	public void load(String countKey, UUID postId) {
+		if (doesNotExistViewCountInRedis(countKey)) {
+			RLock viewCountLock = redissonClient.getLock(countKey + LOCK_KEY_SUFFIX);
+			boolean isLocked = false;
+
+			try {
+				isLocked = viewCountLock.tryLock(LOCK_WAIT_TIME, LOCK_LEASE_TIME, TimeUnit.SECONDS);
+
+				if (isLocked) {
+					loadViewCountFromDBToRedis(countKey, postId);
+				}
+			} catch (InterruptedException e) {
+				throw new CustomException(REDIS_UNAVAILABLE);
+			} finally {
+				if (isLocked && viewCountLock.isHeldByCurrentThread()) {
+					viewCountLock.unlock();
+				}
+			}
+		}
+
+		redisTemplate.expire(countKey, Duration.ofHours(DAILY_TTL_HOURS));
+	}
+
+	private void loadViewCountFromDBToRedis(String countKey, UUID postId) {
+		if (doesNotExistViewCountInRedis(countKey)) {
+			Post post = postRepository.findById(postId)
+				.orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+			redisTemplate.opsForValue().set(countKey, String.valueOf(post.getViewCount()));
+		}
+	}
+
+	private boolean doesNotExistViewCountInRedis(String countKey) {
+		return !redisTemplate.hasKey(countKey);
+	}
+}

--- a/src/test/java/api/store/diglog/DiglogApplicationTests.java
+++ b/src/test/java/api/store/diglog/DiglogApplicationTests.java
@@ -2,7 +2,10 @@ package api.store.diglog;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class DiglogApplicationTests {
 

--- a/src/test/java/api/store/diglog/repository/PostViewBatchRepositoryImplTest.java
+++ b/src/test/java/api/store/diglog/repository/PostViewBatchRepositoryImplTest.java
@@ -1,0 +1,129 @@
+package api.store.diglog.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import api.store.diglog.model.constant.Platform;
+import api.store.diglog.model.constant.Role;
+import api.store.diglog.model.entity.Folder;
+import api.store.diglog.model.entity.Member;
+import api.store.diglog.model.entity.Post;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PostViewBatchRepositoryImplTest {
+
+	@Autowired
+	private PostViewBatchRepository postViewBatchRepository;
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private FolderRepository folderRepository;
+
+	private List<Member> members;
+	private List<Folder> folders;
+
+	@BeforeEach
+	void setUp() {
+
+		members = memberRepository.saveAll(
+			IntStream.range(0, 5)
+				.mapToObj(i -> Member.builder()
+					.email("Frod" + i + "@gmail.com")
+					.username("Frod" + i)
+					.password("FrodPassword" + i)
+					.roles(Set.of(Role.ROLE_USER))
+					.platform(Platform.SERVER)
+					.createdAt(LocalDateTime.of(2022, 2 + i, 22, 12, 0))
+					.updatedAt(LocalDateTime.of(2022, 3 + i, 22, 12, 0))
+					.build())
+				.toList()
+		);
+
+		folders = folderRepository.saveAll(
+			IntStream.range(0, 5)
+				.mapToObj(i -> Folder.builder()
+					.id(UUID.randomUUID())
+					.member(members.get(i))
+					.title("diglog" + i)
+					.depth(0)
+					.orderIndex(0)
+					.parentFolder(null)
+					.build())
+				.toList()
+		);
+
+	}
+
+	@AfterEach
+	void tearDown() {
+		postRepository.deleteAllInBatch();
+		folderRepository.deleteAllInBatch();
+		memberRepository.deleteAllInBatch();
+	}
+
+	@DisplayName("여러 게시글의 조회수를 일괄적으로 업데이트 할 수 있다.")
+	@Test
+	void bulkUpdateViewCounts() {
+
+		// given
+		List<Post> posts = postRepository.saveAll(
+			IntStream.range(0, 5)
+				.mapToObj(i -> postRepository.save(Post.builder()
+					.title("title" + i)
+					.content("content" + i)
+					.viewCount(i)
+					.member(members.get(i))
+					.folder(folders.get(i))
+					.build()))
+				.toList()
+		);
+
+		Map<UUID, Long> updatePosts = posts.stream()
+			.collect(Collectors.toMap(
+				Post::getId,
+				post -> post.getViewCount() + 10
+			));
+
+		// when
+		postViewBatchRepository.bulkUpdateViewCounts(updatePosts);
+
+		// then
+		List<Post> resultPosts = postRepository.findAllById(
+			posts.stream()
+				.map(Post::getId)
+				.toList()
+		);
+
+		assertThat(resultPosts)
+			.extracting("id", "viewCount")
+			.containsExactlyInAnyOrderElementsOf(
+				updatePosts.keySet()
+					.stream()
+					.map(postId -> tuple(postId, updatePosts.get(postId)))
+					.toList()
+			);
+
+	}
+
+}

--- a/src/test/java/api/store/diglog/service/PostServiceTest.java
+++ b/src/test/java/api/store/diglog/service/PostServiceTest.java
@@ -1,0 +1,402 @@
+package api.store.diglog.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import api.store.diglog.common.exception.CustomException;
+import api.store.diglog.model.constant.Platform;
+import api.store.diglog.model.constant.Role;
+import api.store.diglog.model.dto.post.PostViewIncrementRequest;
+import api.store.diglog.model.dto.post.PostViewResponse;
+import api.store.diglog.model.entity.Folder;
+import api.store.diglog.model.entity.Member;
+import api.store.diglog.model.entity.Post;
+import api.store.diglog.repository.FolderRepository;
+import api.store.diglog.repository.MemberRepository;
+import api.store.diglog.repository.PostRepository;
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class PostServiceTest {
+	@Container
+	static GenericContainer<?> redisContainer = new GenericContainer<>("redis:7.2")
+		.withExposedPorts(6379)
+		.waitingFor(Wait.forListeningPort());
+
+	@DynamicPropertySource
+	static void overrideRedisProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.redis.host", redisContainer::getHost);
+		registry.add("spring.redis.port", () -> redisContainer.getMappedPort(6379));
+	}
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private FolderRepository folderRepository;
+
+	@MockitoSpyBean
+	private PostRepository postRepository;
+
+	@Autowired
+	private PostService postService;
+
+	@Autowired
+	private RedisTemplate<String, String> redisTemplate;
+
+	@Autowired
+	private RedissonClient redissonClient;
+
+	private Member member;
+
+	private Folder folder;
+
+	@BeforeEach
+	void setUp() {
+
+		member = memberRepository.save(Member.builder()
+			.email("Frod@gmail.com")
+			.username("Frod")
+			.password("FrodPassword")
+			.roles(Set.of(Role.ROLE_USER))
+			.platform(Platform.SERVER)
+			.createdAt(LocalDateTime.of(2022, 2, 22, 12, 0))
+			.updatedAt(LocalDateTime.of(2022, 3, 22, 12, 0))
+			.build());
+
+		folder = folderRepository.save(Folder.builder()
+			.id(UUID.randomUUID())
+			.member(member)
+			.title("diglog")
+			.depth(0)
+			.orderIndex(0)
+			.parentFolder(null)
+			.build());
+
+	}
+
+	@AfterEach
+	void tearDown() {
+		postRepository.deleteAllInBatch();
+		folderRepository.deleteAllInBatch();
+		memberRepository.deleteAllInBatch();
+		redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+	}
+
+	@DisplayName("게시글 조회수를 조회할 수 있다.")
+	@Test
+	void getViewCount() {
+
+		// given
+		Post post = postRepository.save(Post.builder()
+			.member(member)
+			.title("Diglog Redis 적용기")
+			.content("Diglog 프로젝트의 Redis 적용과정")
+			.viewCount(1000L)
+			.folder(folder)
+			.build());
+
+		// when
+		PostViewResponse postViewResponse = postService.getViewCount(post.getId());
+
+		// then
+		assertThat(postViewResponse)
+			.extracting("postId", "viewCount")
+			.containsExactly(post.getId(), post.getViewCount());
+
+		Long ttlSeconds = redisTemplate.getExpire("post:view:count:" + post.getId(), TimeUnit.SECONDS);
+		assertThat(ttlSeconds).isGreaterThan(0L);
+		assertThat(ttlSeconds).isLessThanOrEqualTo(Duration.ofHours(24).getSeconds());
+	}
+
+	@DisplayName("존재하지 않는 게시글의 조회수는 조회할 수 없다.")
+	@Test
+	void getViewCount_OfNotExistPost() {
+
+		// given
+		UUID notExistPostId = UUID.fromString("aaaaaaaa-1111-2222-3333-123456789012");
+
+		// when, then
+		assertThatThrownBy(() -> postService.getViewCount(notExistPostId))
+			.isInstanceOf(CustomException.class)
+			.hasMessage("해당 게시글이 없습니다.");
+	}
+
+	@DisplayName("레디스의 조회수를 증가시킬 수 있다.")
+	@Test
+	void increaseView() {
+
+		// given
+		Post post = postRepository.save(Post.builder()
+			.member(member)
+			.title("Diglog Redis 적용기")
+			.content("Diglog 프로젝트의 Redis 적용과정")
+			.viewCount(100L)
+			.folder(folder)
+			.build());
+
+		PostViewIncrementRequest postViewIncrementRequest = PostViewIncrementRequest.builder()
+			.postId(post.getId())
+			.build();
+
+		// when
+		postService.increaseView(postViewIncrementRequest, "10.0.0.1");
+
+		// then
+		long viewCount = Long.parseLong(redisTemplate.opsForValue().get("post:view:count:" + post.getId()));
+		assertThat(viewCount).isEqualTo(post.getViewCount() + 1);
+
+		Long ttlSeconds = redisTemplate.getExpire("post:view:count:" + post.getId(), TimeUnit.SECONDS);
+		assertThat(ttlSeconds).isGreaterThan(0L);
+		assertThat(ttlSeconds).isLessThanOrEqualTo(Duration.ofHours(24).getSeconds());
+	}
+
+	@DisplayName("조회수 증가 시 dirtySet에 게시글 ID가 추가된다.")
+	@Test
+	void increaseView_shouldAddToDirtySet() {
+		// given
+		Post post = postRepository.save(Post.builder()
+			.member(member)
+			.title("Diglog Redis 적용기")
+			.content("Diglog 프로젝트의 Redis 적용과정")
+			.viewCount(1000L)
+			.folder(folder)
+			.build());
+		UUID postId = post.getId();
+		String ip = "192.168.0.1";
+		PostViewIncrementRequest request = PostViewIncrementRequest.builder().postId(postId).build();
+
+		// when
+		postService.increaseView(request, ip);
+
+		// then
+		Set<String> dirtySet = redisTemplate.opsForSet().members("post:view:dirtySet");
+		assertThat(dirtySet).contains(postId.toString());
+	}
+
+	@DisplayName("일정 시간 내에 같은 ip에서 조회수 증가를 여러번 요청한 경우, 첫 조회수 요청에서만 조회수가 증가된다.")
+	@Test
+	void increaseView_WithSameIpAddressRequests() {
+
+		// given
+		Post post = postRepository.save(Post.builder()
+			.member(member)
+			.title("Diglog Redis 적용기")
+			.content("Diglog 프로젝트의 Redis 적용과정")
+			.viewCount(100L)
+			.folder(folder)
+			.build());
+		UUID postId = post.getId();
+
+		PostViewIncrementRequest postViewIncrementRequest = PostViewIncrementRequest.builder()
+			.postId(postId)
+			.build();
+
+		String ipAddress = "10.0.0.1";
+		String ipKey = "post:view:" + postId + ":" + ipAddress;
+		String countKey = "post:view:count:" + postId;
+
+		redisTemplate.opsForValue().set(ipKey, "true", Duration.ofHours(24));
+		redisTemplate.opsForValue().set(countKey, String.valueOf(post.getViewCount()), Duration.ofHours(24));
+
+		// when
+		postService.increaseView(postViewIncrementRequest, ipAddress);
+
+		// then
+		long viewCount = Long.parseLong(redisTemplate.opsForValue().get("post:view:count:" + post.getId()));
+		assertThat(viewCount).isEqualTo(post.getViewCount());
+	}
+
+	@DisplayName("TTL이 만료된 후에는 같은 ip의 조회수 증가 요청에도 조회수가 증가한다.")
+	@Test
+	void increaseView_afterTtlExpired() throws InterruptedException {
+
+		// given
+		Post post = postRepository.save(Post.builder()
+			.member(member)
+			.title("Diglog Redis 적용기")
+			.content("Diglog 프로젝트의 Redis 적용과정")
+			.viewCount(100L)
+			.folder(folder)
+			.build());
+
+		UUID postId = post.getId();
+
+		PostViewIncrementRequest postViewIncrementRequest = PostViewIncrementRequest.builder()
+			.postId(postId)
+			.build();
+
+		String ipAddress = "10.0.0.1";
+		String ipKey = "post:view:" + postId + ":" + ipAddress;
+		String countKey = "post:view:count:" + postId;
+
+		redisTemplate.opsForValue().set(ipKey, "true", Duration.ofMillis(10));
+		redisTemplate.opsForValue().set(countKey, String.valueOf(post.getViewCount()), Duration.ofHours(24));
+
+		Thread.sleep(100);
+
+		// when
+		postService.increaseView(postViewIncrementRequest, ipAddress);
+
+		// then
+		long viewCount = Long.parseLong(redisTemplate.opsForValue().get(countKey));
+		assertThat(viewCount).isEqualTo(post.getViewCount() + 1);
+	}
+
+	@DisplayName("레디스에 조회수가 이미 존재하면 DB를 조회하지 않는다.")
+	@Test
+	void loadPostViewIntoRedis_shouldNotQueryDb_whenCacheExists() {
+		// given
+		Post post = postRepository.save(Post.builder()
+			.member(member)
+			.title("Diglog Redis 적용기")
+			.content("Diglog 프로젝트의 Redis 적용과정")
+			.viewCount(100L)
+			.folder(folder)
+			.build());
+		UUID postId = post.getId();
+		String countKey = "post:view:count:" + postId;
+		redisTemplate.opsForValue().set(countKey, "999");
+
+		// when
+		postService.getViewCount(postId);
+
+		// then
+		verify(postRepository, never()).findById(postId);
+	}
+
+	@DisplayName("레디스에 적재되어 있지 않은 게시글의 조회수 증가 동시 요청에도 조회수가 누락되지 않는다.")
+	@Test
+	void increaseView_withConcurrentRequests_shouldNotMiss() throws Exception {
+		// given
+		Post post = postRepository.save(Post.builder()
+			.title("락 테스트")
+			.content("동시성")
+			.viewCount(100L)
+			.member(member)
+			.folder(folder)
+			.build());
+
+		UUID postId = post.getId();
+		String countKey = "post:view:count:" + postId;
+		String redisLockKey = countKey + ":lock";
+
+		int threadCount = 30;
+		try (ExecutorService executor = Executors.newFixedThreadPool(threadCount)) {
+
+			CountDownLatch readyLatch = new CountDownLatch(threadCount);
+			CountDownLatch startLatch = new CountDownLatch(1);
+			CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+			RLock lock = redissonClient.getLock(redisLockKey);
+			lock.lock();
+
+			for (int i = 0; i < threadCount; i++) {
+				int userIndex = i;
+				executor.submit(() -> {
+					try {
+						PostViewIncrementRequest request = PostViewIncrementRequest.builder()
+							.postId(postId)
+							.build();
+						String ip = "10.0.0." + userIndex;
+
+						readyLatch.countDown();
+						startLatch.await();
+
+						postService.increaseView(request, ip);
+						System.out.println(ip + " : " + redisTemplate.opsForValue().get(countKey));
+
+					} catch (InterruptedException e) {
+						throw new RuntimeException(e);
+
+					} finally {
+						doneLatch.countDown();
+					}
+				});
+			}
+
+			readyLatch.await();
+
+			lock.unlock();
+			startLatch.countDown();
+
+			doneLatch.await();
+			executor.shutdown();
+		}
+
+		// then
+		String value = redisTemplate.opsForValue().get(countKey);
+		assertThat(value).isNotNull();
+		assertThat(Long.parseLong(value)).isEqualTo(post.getViewCount() + threadCount);
+	}
+
+	@DisplayName("존재하지 않는 게시글의 조회수는 증가시킬 수 없다.")
+	@Test
+	void increaseView_OfNotExistPost() {
+
+		// given
+		UUID notExistPostId = UUID.fromString("12345678-aaaa-bbbb-cccc-123456789012");
+		PostViewIncrementRequest postViewIncrementRequest = PostViewIncrementRequest.builder()
+			.postId(notExistPostId)
+			.build();
+
+		// when, then
+		assertThatThrownBy(() -> postService.increaseView(postViewIncrementRequest, "10.0.0.1"))
+			.isInstanceOf(CustomException.class)
+			.hasMessage("해당 게시글이 없습니다.");
+	}
+
+	@DisplayName("조회수 증가 후 조회 시 증가된 값이 반환된다.")
+	@Test
+	void getViewCount_afterIncreaseView() {
+		// given
+		Post post = postRepository.save(Post.builder()
+			.member(member)
+			.title("Diglog Redis 적용기")
+			.content("Diglog 프로젝트의 Redis 적용과정")
+			.viewCount(100L)
+			.folder(folder)
+			.build());
+		UUID postId = post.getId();
+		PostViewIncrementRequest request = PostViewIncrementRequest.builder()
+			.postId(postId)
+			.build();
+
+		postService.increaseView(request, "10.0.0.1");
+
+		// when
+		PostViewResponse response = postService.getViewCount(postId);
+
+		// then
+		assertThat(response.getViewCount()).isEqualTo(post.getViewCount() + 1);
+	}
+
+}

--- a/src/test/java/api/store/diglog/service/PostServiceTest.java
+++ b/src/test/java/api/store/diglog/service/PostServiceTest.java
@@ -613,7 +613,7 @@ class PostServiceTest extends RedisTestSupporter {
 		postService.syncPostViewCountToDb();
 
 		// then
-		await().atMost(7, TimeUnit.SECONDS).untilAsserted(
+		await().atMost(15, TimeUnit.SECONDS).untilAsserted(
 			() -> assertAll(
 				() -> verify(postViewBatchRepository, times(expectedMethodCallCount)).bulkUpdateViewCounts(any()),
 				() -> {

--- a/src/test/java/api/store/diglog/service/post/PostAsyncWorkerTest.java
+++ b/src/test/java/api/store/diglog/service/post/PostAsyncWorkerTest.java
@@ -15,6 +15,7 @@ import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -108,6 +109,7 @@ class PostAsyncWorkerTest {
 		redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
 	}
 
+	@DisplayName("게시글의 조회수의 업데이트와 Redis의 조회수 관련 DirtySet을 초기화를 비동기로 처리한다.")
 	@Test
 	void syncViewCountAllInBatch() {
 

--- a/src/test/java/api/store/diglog/service/post/PostAsyncWorkerTest.java
+++ b/src/test/java/api/store/diglog/service/post/PostAsyncWorkerTest.java
@@ -1,0 +1,164 @@
+package api.store.diglog.service.post;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import api.store.diglog.model.constant.Platform;
+import api.store.diglog.model.constant.Role;
+import api.store.diglog.model.entity.Folder;
+import api.store.diglog.model.entity.Member;
+import api.store.diglog.model.entity.Post;
+import api.store.diglog.repository.FolderRepository;
+import api.store.diglog.repository.MemberRepository;
+import api.store.diglog.repository.PostRepository;
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class PostAsyncWorkerTest {
+	@Container
+	static GenericContainer<?> redisContainer = new GenericContainer<>("redis:7.2")
+		.withExposedPorts(6379)
+		.waitingFor(Wait.forListeningPort());
+
+	@DynamicPropertySource
+	static void overrideRedisProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.redis.host", redisContainer::getHost);
+		registry.add("spring.redis.port", () -> redisContainer.getMappedPort(6379));
+	}
+
+	@Autowired
+	private PostAsyncWorker postAsyncWorker;
+	@Autowired
+	private PostRepository postRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private FolderRepository folderRepository;
+	@Autowired
+	private RedisTemplate<String, String> redisTemplate;
+
+	private static final String COUNT_PREFIX = "post:view:count:";
+	private static final String DIRTY_SET = "post:view:dirtySet";
+
+	private List<Member> members;
+	private List<Folder> folders;
+
+	@BeforeEach
+	void setUp() {
+
+		members = memberRepository.saveAll(
+			IntStream.range(0, 5)
+				.mapToObj(i -> Member.builder()
+					.email("Frod" + i + "@gmail.com")
+					.username("Frod" + i)
+					.password("FrodPassword" + i)
+					.roles(Set.of(Role.ROLE_USER))
+					.platform(Platform.SERVER)
+					.createdAt(LocalDateTime.of(2022, 2 + i, 22, 12, 0))
+					.updatedAt(LocalDateTime.of(2022, 3 + i, 22, 12, 0))
+					.build())
+				.toList()
+		);
+
+		folders = folderRepository.saveAll(
+			IntStream.range(0, 5)
+				.mapToObj(i -> Folder.builder()
+					.id(UUID.randomUUID())
+					.member(members.get(i))
+					.title("diglog" + i)
+					.depth(0)
+					.orderIndex(0)
+					.parentFolder(null)
+					.build())
+				.toList()
+		);
+
+	}
+
+	@AfterEach
+	void tearDown() {
+		postRepository.deleteAllInBatch();
+		folderRepository.deleteAllInBatch();
+		memberRepository.deleteAllInBatch();
+		redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+	}
+
+	@Test
+	void syncViewCountAllInBatch() {
+
+		// given
+		List<Post> posts = postRepository.saveAll(
+			IntStream.range(0, 5)
+				.mapToObj(i -> postRepository.save(Post.builder()
+					.title("title" + i)
+					.content("content" + i)
+					.viewCount(i)
+					.member(members.get(i))
+					.folder(folders.get(i))
+					.build()))
+				.toList()
+		);
+
+		Map<UUID, Long> updateViewCount = posts.stream()
+			.collect(Collectors.toMap(
+				Post::getId,
+				post -> post.getViewCount() * 2
+			));
+
+		for (UUID postId : updateViewCount.keySet()) {
+			redisTemplate.opsForValue().set(COUNT_PREFIX + postId, String.valueOf(updateViewCount.get(postId)));
+			redisTemplate.opsForSet().add(DIRTY_SET, postId.toString());
+		}
+
+		List<UUID> postIds = posts.stream()
+			.map(Post::getId)
+			.toList();
+
+		// when
+		postAsyncWorker.syncViewCountAllInBatch(postIds);
+
+		// then
+		List<Post> updatedPosts = postRepository.findAllById(postIds);
+		await().atMost(2, TimeUnit.SECONDS)
+			.untilAsserted(() ->
+				assertAll(
+					() -> assertThat(updatedPosts)
+						.extracting("id", "viewCount")
+						.containsExactlyInAnyOrderElementsOf(
+							updateViewCount.keySet().stream()
+								.map(postId -> tuple(postId, updateViewCount.get(postId)))
+								.toList()
+						),
+					() -> assertThat(redisTemplate.opsForSet().members(DIRTY_SET))
+						.isEmpty()
+				)
+			);
+
+	}
+
+}

--- a/src/test/java/api/store/diglog/service/post/PostAsyncWorkerTest.java
+++ b/src/test/java/api/store/diglog/service/post/PostAsyncWorkerTest.java
@@ -21,12 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import api.store.diglog.model.constant.Platform;
 import api.store.diglog.model.constant.Role;
@@ -36,21 +30,11 @@ import api.store.diglog.model.entity.Post;
 import api.store.diglog.repository.FolderRepository;
 import api.store.diglog.repository.MemberRepository;
 import api.store.diglog.repository.PostRepository;
+import api.store.diglog.supporter.RedisTestSupporter;
 
-@Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
-class PostAsyncWorkerTest {
-	@Container
-	static GenericContainer<?> redisContainer = new GenericContainer<>("redis:7.2")
-		.withExposedPorts(6379)
-		.waitingFor(Wait.forListeningPort());
-
-	@DynamicPropertySource
-	static void overrideRedisProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.redis.host", redisContainer::getHost);
-		registry.add("spring.redis.port", () -> redisContainer.getMappedPort(6379));
-	}
+class PostAsyncWorkerTest extends RedisTestSupporter {
 
 	@Autowired
 	private PostAsyncWorker postAsyncWorker;

--- a/src/test/java/api/store/diglog/service/post/RedisPostViewLoaderTest.java
+++ b/src/test/java/api/store/diglog/service/post/RedisPostViewLoaderTest.java
@@ -1,0 +1,124 @@
+package api.store.diglog.service.post;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import api.store.diglog.model.constant.Platform;
+import api.store.diglog.model.constant.Role;
+import api.store.diglog.model.entity.Folder;
+import api.store.diglog.model.entity.Member;
+import api.store.diglog.model.entity.Post;
+import api.store.diglog.repository.FolderRepository;
+import api.store.diglog.repository.MemberRepository;
+import api.store.diglog.repository.PostRepository;
+import api.store.diglog.supporter.RedisTestSupporter;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class RedisPostViewLoaderTest extends RedisTestSupporter {
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private FolderRepository folderRepository;
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@Autowired
+	private RedisTemplate<String, String> redisTemplate;
+
+	@Autowired
+	private RedisPostViewLoader redisPostViewLoader;
+
+	private Member member;
+
+	private Folder folder;
+
+	@BeforeEach
+	void setUp() {
+
+		member = memberRepository.save(Member.builder()
+			.email("Frod@gmail.com")
+			.username("Frod")
+			.password("FrodPassword")
+			.roles(Set.of(Role.ROLE_USER))
+			.platform(Platform.SERVER)
+			.createdAt(LocalDateTime.of(2022, 2, 22, 12, 0))
+			.updatedAt(LocalDateTime.of(2022, 3, 22, 12, 0))
+			.build());
+
+		folder = folderRepository.save(Folder.builder()
+			.id(UUID.randomUUID())
+			.member(member)
+			.title("diglog")
+			.depth(0)
+			.orderIndex(0)
+			.parentFolder(null)
+			.build());
+
+	}
+
+	@AfterEach
+	void tearDown() {
+		postRepository.deleteAllInBatch();
+		folderRepository.deleteAllInBatch();
+		memberRepository.deleteAllInBatch();
+		redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+	}
+
+	@DisplayName("레디스에 게시글의 조회수가 없는 경우, DB에서 조회해와서 레디스에 조회수를 적재한다.")
+	@Test
+	void loadPostViewIntoRedis_shouldStoreViewCount_whenNotExistInRedis() {
+		// given
+		Post post = postRepository.save(Post.builder()
+			.member(member)
+			.title("Diglog Redis 적용기")
+			.content("Diglog 프로젝트의 Redis 적용과정")
+			.viewCount(1000L)
+			.folder(folder)
+			.build());
+		String redisKey = "post:view:count:" + post.getId();
+
+		// when
+		redisPostViewLoader.load(redisKey, post.getId());
+
+		// then
+		String redisValue = redisTemplate.opsForValue().get(redisKey);
+		assertThat(redisValue).isEqualTo("1000");
+	}
+
+	@DisplayName("레디스에 게시글의 조회수가 있는 경우, 레디스의 조회수가 덮어씌워지지 않는다.")
+	@Test
+	void loadPostViewIntoRedis_shouldNotOverwrite_whenExistsInRedis() {
+		// given
+		Post post = postRepository.save(Post.builder()
+			.member(member)
+			.title("Diglog Redis 적용기")
+			.content("Diglog 프로젝트의 Redis 적용과정")
+			.viewCount(1000L)
+			.folder(folder)
+			.build());
+
+		String redisKey = "post:view:count:" + post.getId();
+		redisTemplate.opsForValue().set(redisKey, "9999");
+
+		// when
+		redisPostViewLoader.load(redisKey, post.getId());
+
+		// then
+		assertThat(redisTemplate.opsForValue().get(redisKey)).isEqualTo("9999");
+	}
+}

--- a/src/test/java/api/store/diglog/supporter/RedisTestSupporter.java
+++ b/src/test/java/api/store/diglog/supporter/RedisTestSupporter.java
@@ -3,17 +3,21 @@ package api.store.diglog.supporter;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 public abstract class RedisTestSupporter {
 
-	@Container
-	static GenericContainer<?> redisContainer = new GenericContainer<>("redis:7.2")
-		.withExposedPorts(6379)
-		.waitingFor(Wait.forListeningPort());
+	private static final GenericContainer<?> redisContainer;
+
+	static {
+		redisContainer = new GenericContainer<>(DockerImageName.parse("redis:7.2"))
+			.withExposedPorts(6379)
+			.withReuse(true);
+
+		redisContainer.start();
+	}
 
 	@DynamicPropertySource
 	static void overrideRedisProperties(DynamicPropertyRegistry registry) {

--- a/src/test/java/api/store/diglog/supporter/RedisTestSupporter.java
+++ b/src/test/java/api/store/diglog/supporter/RedisTestSupporter.java
@@ -1,0 +1,23 @@
+package api.store.diglog.supporter;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public abstract class RedisTestSupporter {
+
+	@Container
+	static GenericContainer<?> redisContainer = new GenericContainer<>("redis:7.2")
+		.withExposedPorts(6379)
+		.waitingFor(Wait.forListeningPort());
+
+	@DynamicPropertySource
+	static void overrideRedisProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.redis.host", redisContainer::getHost);
+		registry.add("spring.redis.port", () -> redisContainer.getMappedPort(6379));
+	}
+}


### PR DESCRIPTION
## 📝 요약(Summary)

조회수 기능에 Redis 기반 캐싱 시스템과 비동기 DB 동기화 로직을 구현했습니다.

### 주요 기능

+ 조회수 증가 시 Redis에 게시글별로 저장하며, IP 기준 24시간 중복 조회 방지 적용
+ 배치 단위로 Redis 데이터를 DB에 비동기 동기화하며, 무효한 값(null, 파싱 불가능한 문자열, 역전된 값 등) 필터링 처리
+ 테스트 안정성 향상을 위해 Redis 컨테이너 재사용 방식으로 변경하여 테스트 로딩 시간 단축

### 테스트 인프라 개선

+ Redis 테스트 컨테이너 의존성 추가
+ 클래스별 컨테이너 생성 방식에서 컨테이너 재사용 방식으로 변경하여 테스트 중 Redis 컨테이너 종료 문제 해결

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어 (선택)

Redis 동기화 과정에서 무효한 값(null, "not number", DB 값보다 작은 값)을 발견할 경우, 해당 데이터는 동기화에서 제외하되 로그만 기록하고 DirtySet에서는 유지하는 방식을 적용했습니다. 서버 내부 동작 특성상 예외 발생보다는 로그를 통한 모니터링이 적절하다고 판단했으나, Redis 데이터 오염 감지 시 처리 방안에 대해 논의가 필요합니다:
+ 자동 초기화 메커니즘 구현
+ 관리자 개입을 통한 반자동 처리 방식

어떤 방향이 더 적합할지 의견 부탁드립니다.
