### PR TITLE
fix: post, comment 생성 시 id를 return 하도록 변경

### DIFF
--- a/src/main/java/api/store/diglog/controller/CommentController.java
+++ b/src/main/java/api/store/diglog/controller/CommentController.java
@@ -1,5 +1,6 @@
 package api.store.diglog.controller;
 
+import api.store.diglog.model.dto.comment.CommentCreateResponse;
 import api.store.diglog.model.dto.comment.CommentListRequest;
 import api.store.diglog.model.dto.comment.CommentRequest;
 import api.store.diglog.model.dto.comment.CommentResponse;
@@ -24,10 +25,10 @@ public class CommentController {
 	private final CommentService commentService;
 
 	@PostMapping
-	public ResponseEntity<Void> save(@RequestBody CommentRequest commentRequest) {
-		commentService.save(commentRequest);
+	public ResponseEntity<CommentCreateResponse> save(@RequestBody CommentRequest commentRequest) {
+		CommentCreateResponse commentCreateResponse = commentService.save(commentRequest);
 
-		return ResponseEntity.status(HttpStatusCode.CREATED).build();
+		return ResponseEntity.status(HttpStatusCode.CREATED).body(commentCreateResponse);
 	}
 
 	@GetMapping

--- a/src/main/java/api/store/diglog/controller/PostController.java
+++ b/src/main/java/api/store/diglog/controller/PostController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import api.store.diglog.model.dto.post.PostCreateResponse;
 import api.store.diglog.model.dto.post.PostFolderUpdateRequest;
 import api.store.diglog.model.dto.post.PostListMemberRequest;
 import api.store.diglog.model.dto.post.PostListMemberTagRequest;
@@ -26,6 +27,7 @@ import api.store.diglog.model.dto.post.PostViewResponse;
 import api.store.diglog.service.post.PostService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.http.HttpStatusCode;
 
 @RestController
 @RequestMapping("/api/post")
@@ -35,10 +37,10 @@ public class PostController {
 	private final PostService postService;
 
 	@PostMapping
-	public ResponseEntity<Void> save(@RequestBody PostRequest postRequest) {
-		postService.save(postRequest);
+	public ResponseEntity<PostCreateResponse> save(@RequestBody PostRequest postRequest) {
+		PostCreateResponse postCreateResponse = postService.save(postRequest);
 
-		return ResponseEntity.ok().build();
+		return ResponseEntity.status(HttpStatusCode.CREATED).body(postCreateResponse);
 	}
 
 	@PatchMapping

--- a/src/main/java/api/store/diglog/model/dto/comment/CommentCreateResponse.java
+++ b/src/main/java/api/store/diglog/model/dto/comment/CommentCreateResponse.java
@@ -1,0 +1,18 @@
+package api.store.diglog.model.dto.comment;
+
+import java.util.UUID;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentCreateResponse {
+
+	private UUID id;
+}

--- a/src/main/java/api/store/diglog/model/dto/post/PostCreateResponse.java
+++ b/src/main/java/api/store/diglog/model/dto/post/PostCreateResponse.java
@@ -1,0 +1,18 @@
+package api.store.diglog.model.dto.post;
+
+import java.util.UUID;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostCreateResponse {
+
+	private UUID id;
+}

--- a/src/main/java/api/store/diglog/service/CommentService.java
+++ b/src/main/java/api/store/diglog/service/CommentService.java
@@ -1,6 +1,7 @@
 package api.store.diglog.service;
 
 import api.store.diglog.common.exception.CustomException;
+import api.store.diglog.model.dto.comment.CommentCreateResponse;
 import api.store.diglog.model.dto.comment.CommentListRequest;
 import api.store.diglog.model.dto.comment.CommentRequest;
 import api.store.diglog.model.dto.comment.CommentResponse;
@@ -32,7 +33,7 @@ public class CommentService {
 	private final MemberService memberService;
 
 	@Transactional
-	public void save(CommentRequest commentRequest) {
+	public CommentCreateResponse save(CommentRequest commentRequest) {
 		Member member = memberService.getCurrentMember();
 		Post post = Post.builder().id(commentRequest.getPostId()).build();
 		Comment parentComment = getParentComment(commentRequest.getParentCommentId());
@@ -46,6 +47,10 @@ public class CommentService {
 			.taggedMember(taggedMember)
 			.build();
 		commentRepository.save(comment);
+
+		return CommentCreateResponse.builder()
+			.id(comment.getId())
+			.build();
 	}
 
 	private Comment getParentComment(UUID parentCommentId) {

--- a/src/main/java/api/store/diglog/service/post/PostService.java
+++ b/src/main/java/api/store/diglog/service/post/PostService.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import api.store.diglog.common.exception.CustomException;
 import api.store.diglog.common.util.BatchPartition;
 import api.store.diglog.model.constant.SearchOption;
+import api.store.diglog.model.dto.post.PostCreateResponse;
 import api.store.diglog.model.dto.post.PostFolderUpdateRequest;
 import api.store.diglog.model.dto.post.PostListMemberRequest;
 import api.store.diglog.model.dto.post.PostListMemberTagRequest;
@@ -66,7 +67,7 @@ public class PostService {
 	private final RedisPostViewLoader redisPostViewLoader;
 
 	@Transactional
-	public void save(PostRequest postRequest) {
+	public PostCreateResponse save(PostRequest postRequest) {
 		Member member = memberService.getCurrentMember();
 		List<Tag> tags = saveNewTags(postRequest.getTagNames());
 		Folder folder = folderService.getFolderByIdAndMemberId(postRequest.getFolderId(), member.getId());
@@ -85,6 +86,10 @@ public class PostService {
 			.urls(postRequest.getUrls())
 			.build();
 		imageService.savePostImage(imagePostVO);
+
+		return PostCreateResponse.builder()
+			.id(savedPost.getId())
+			.build();
 	}
 
 	@Transactional


### PR DESCRIPTION
## 📝 요약(Summary)

- post, comment 생성 시 알림에 필요한 id를 response에 포함하도록 변경

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어 (선택)

## 📸스크린샷 (선택)
